### PR TITLE
Fix typo: cybozu

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "CyboMonitor",
     "version": "1.2",
-    "description": "Cybozeの報告書と掲示板への書き込みを監視",
+    "description": "Cybozuの報告書と掲示板への書き込みを監視",
     "icons": { "48": "icons/icon_048.png",
               "128": "icons/icon_128.png" },
     "background": {


### PR DESCRIPTION
Cybozuが正式らしいので修正しました。
Chromeウェブストアに表示される説明文のほうも同時に直るのかどうか
こちらではわからなかったので、そちらはお手数ですが対応お願いします。
